### PR TITLE
Bump build number and build with rust 1.82

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  number: 1
+  number: 2
   missing_dso_whitelist:
     - '$RPATH/ld64.so.1'      # [s390x]
 


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-6217](https://anaconda.atlassian.net/browse/PKG-6217)
 
### Explanation of changes:
  - Bump build number and build with rust 1.82

Rust < 1.81 was affected by CVE-2024-43402.

[PKG-6217]: https://anaconda.atlassian.net/browse/PKG-6217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ